### PR TITLE
Attachment-to-e2t dim down file remove button

### DIFF
--- a/css/orgaction.css
+++ b/css/orgaction.css
@@ -437,3 +437,20 @@ blockquote:before {
 .pgbar-current {
   background-color: #bf2026;
 }
+
+/* Styles to dim down the remove button on file upload */
+input[id$=remove-button] {
+  text-shadow: none;
+  font-weight: normal;
+  font-size: 100%;
+  color: #636363;
+  border: 1px solid #b4b1ae;
+  background: #e5e4e3;
+  padding: .5em 1em;
+}
+
+input[id$=remove-button]:hover, input[id$=remove-button]:focus {
+  background: #cccbc9 !important;
+  border: 1px solid #b4b1ae !important;
+  color: #636363 !important;
+}


### PR DESCRIPTION
When you upload a file on a webform, you will also see a "Remove" button, to remove the already uploaded file. As the same button styles apply as everywhere it is too big and too red, and since the focus should be on submitting the form and not on removing the file, these additional styles dim down the remove button, making it grey and small.